### PR TITLE
Don't specify crate-type = dylib in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 
 [lib]
 name = "tenacious"
-crate_type = ["dylib"]
+plugin = true
 
 [dev-dependencies.compiletest]
 git = "https://github.com/laumann/compiletest-rs.git"


### PR DESCRIPTION
Cargo will take care of this as necessary and otherwise the rlib format is
generally more flexible.